### PR TITLE
Title and content attributes addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,17 @@ Can also be used with the [bem function](https://github.com/drupal-pattern-lab/b
 
 <div {{ add_attributes(additional_attributes) }}></div>
 ```
+
+Can also be used with title_attributes or content_attributes:
+```
+{% set additional_title_attributes = {
+  "class": ["foo__title", "bar__title"],
+} %}
+{% set additional_content_attributes = {
+  "class": ["foo__content", "bar__content"],
+} %}
+
+<h2 {{ add_attributes(additional_title_attributes,'title_attributes') }}></h2>
+<div {{ add_attributes(additional_content_attributes,'content_attributes') }}>
+
+```

--- a/add_attributes.function.php
+++ b/add_attributes.function.php
@@ -6,7 +6,11 @@
 
 use Drupal\Core\Template\Attribute;
 
-$function = new Twig_SimpleFunction('add_attributes', function ($context, $additional_attributes = []) {
+$function = new Twig_SimpleFunction('add_attributes', function ($context, $additional_attributes = [], $attribute_type = 'attributes') {
+  if (!in_array($attribute_type, ['attributes','title_attributes','content_attributes'])) {
+    throw new Exception('Invalid attribute type.');
+  }
+
   if (class_exists('Drupal')) {
     $attributes = new Attribute();
 
@@ -35,21 +39,21 @@ $function = new Twig_SimpleFunction('add_attributes', function ($context, $addit
           }
         }
         // Merge additional attribute values with existing ones.
-        if ($context['attributes']->offsetExists($key)) {
-          $existing_attribute = $context['attributes']->offsetGet($key)->value();
+        if ($context[$attribute_type]->offsetExists($key)) {
+          $existing_attribute = $context[$attribute_type]->offsetGet($key)->value();
           $value = array_merge($existing_attribute, $value);
         }
 
-        $context['attributes']->setAttribute($key, $value);
+        $context[$attribute_type]->setAttribute($key, $value);
       }
     }
 
     // Set all attributes.
-    foreach($context['attributes'] as $key => $value) {
+    foreach($context[$attribute_type] as $key => $value) {
       $attributes->setAttribute($key, $value);
       // Remove this attribute from context so it doesn't filter down to child
       // elements.
-      $context['attributes']->removeAttribute($key);
+      $context[$attribute_type]->removeAttribute($key);
     }
 
     return $attributes;


### PR DESCRIPTION
Since [all templates have access to attributes, title_attributes and content_attributes](https://www.drupal.org/docs/8/theming-drupal-8/using-attributes-in-templates), this PR updates the add_attributes function to take an optional parameter specifying either 'attributes', 'title_attributes' or 'content_attributes' (with the default remaining 'attributes') and add to that variable instead.