### PR TITLE
Function update per 2.x Twig documentation

### DIFF
--- a/add_attributes.function.php
+++ b/add_attributes.function.php
@@ -6,7 +6,7 @@
 
 use Drupal\Core\Template\Attribute;
 
-$function = new Twig_SimpleFunction('add_attributes', function ($context, $additional_attributes = []) {
+$function = new \Twig\TwigFunction('add_attributes', function ($context, $additional_attributes = []) {
   if (class_exists('Drupal')) {
     $attributes = new Attribute();
 


### PR DESCRIPTION
Per [the deprecation notice](https://twig.symfony.com/doc/1.x/deprecated.html#functions), this PR updates the function from `Twig_SimpleFunction` to `\Twig\TwigFunction`. Everything worked OK for me in Pattern Lab and Drupal.